### PR TITLE
Add github workflow to publish to gh-pages branch

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
+          SOURCE: docs/spec/index.bs
+          DESTINATION: docs/spec/index.html


### PR DESCRIPTION
This should auto process the bikeshed on push to main and publish to the gh-pages branch.